### PR TITLE
OpenCDC integration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Test
         run: make test GOTEST_FLAGS="-v -count=1"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.18
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3.2.0
         with:
-          version: v1.42.1
+          version: v1.47.3

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -47,9 +47,10 @@ func TestAcceptance(t *testing.T) {
 
 			GoleakOptions: []goleak.Option{
 				// tail will initialize a InotifyTracker and keep it running
-				// forever as a shared instance
+				// forever as a shared instance, both goroutines belong to it
 				goleak.IgnoreTopFunction("github.com/nxadm/tail/watch.(*InotifyTracker).run"),
-				goleak.IgnoreTopFunction("syscall.syscall6"),
+				goleak.IgnoreTopFunction("syscall.Syscall6"), // linux
+				goleak.IgnoreTopFunction("syscall.syscall6"), // darwin
 			},
 		},
 	})

--- a/acceptance_test.go
+++ b/acceptance_test.go
@@ -1,0 +1,56 @@
+// Copyright © 2022 Meroxa, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	sdk "github.com/conduitio/conduit-connector-sdk"
+	"go.uber.org/goleak"
+)
+
+func TestAcceptance(t *testing.T) {
+	testFile := fmt.Sprintf("%v/acceptance-test-%d.txt", t.TempDir(), time.Now().UnixMicro()%1000)
+
+	t.Logf("using test file %v in acceptance tests", testFile)
+	sdk.AcceptanceTest(t, sdk.ConfigurableAcceptanceTestDriver{
+		Config: sdk.ConfigurableAcceptanceTestDriverConfig{
+			Connector: Connector,
+			SourceConfig: map[string]string{
+				"path": testFile,
+			},
+			DestinationConfig: map[string]string{
+				"path": testFile,
+			},
+
+			AfterTest: func(t *testing.T) {
+				err := os.Remove(testFile)
+				if err != nil && !os.IsNotExist(err) {
+					t.Fatal(err)
+				}
+			},
+
+			GoleakOptions: []goleak.Option{
+				// tail will initialize a InotifyTracker and keep it running
+				// forever as a shared instance
+				goleak.IgnoreTopFunction("github.com/nxadm/tail/watch.(*InotifyTracker).run"),
+				goleak.IgnoreTopFunction("syscall.syscall6"),
+			},
+		},
+	})
+}

--- a/connector.go
+++ b/connector.go
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package file
 
-import (
-	file "github.com/conduitio/conduit-connector-file"
-	sdk "github.com/conduitio/conduit-connector-sdk"
-)
+import sdk "github.com/conduitio/conduit-connector-sdk"
 
-func main() {
-	sdk.Serve(file.Connector)
+var Connector = sdk.Connector{
+	NewSpecification: Specification,
+	NewSource:        NewSource,
+	NewDestination:   NewDestination,
 }

--- a/destination.go
+++ b/destination.go
@@ -58,7 +58,7 @@ func (d *Destination) Open(ctx context.Context) error {
 }
 
 func (d *Destination) Write(ctx context.Context, r sdk.Record) error {
-	_, err := d.file.Write(append(r.Payload.Bytes(), byte('\n')))
+	_, err := d.file.Write(append(r.Bytes(), byte('\n')))
 	return err
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/conduitio/conduit-connector-file
 go 1.17
 
 require (
-	github.com/conduitio/conduit-connector-sdk v0.2.0
+	github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220803121801-c861a0fb207c
 	github.com/nxadm/tail v1.4.8
 )
 
 require (
-	github.com/conduitio/conduit-connector-protocol v0.2.0 // indirect
+	github.com/conduitio/conduit-connector-protocol v0.2.1-0.20220802135043-4b89a6c94401 // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/golang/mock v1.6.0 // indirect
@@ -19,12 +19,15 @@ require (
 	github.com/hashicorp/yamux v0.0.0-20211028200310-0bc27b27de87 // indirect
 	github.com/jhump/protoreflect v1.10.2-0.20220118162304-602a8db873e3 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/matryer/is v1.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/oklog/run v1.1.0 // indirect
-	github.com/rs/zerolog v1.26.1 // indirect
+	github.com/rs/zerolog v1.27.0 // indirect
+	go.buf.build/grpc/go/conduitio/conduit-connector-protocol v1.3.3 // indirect
 	go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol v1.4.1 // indirect
+	go.uber.org/goleak v1.1.12 // indirect
 	golang.org/x/net v0.0.0-20220403103023-749bd193bc2b // indirect
 	golang.org/x/sys v0.0.0-20220405052023-b1e9470b6e64 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/conduitio/conduit-connector-file
 
-go 1.17
+go 1.18
 
 require (
 	github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220803121801-c861a0fb207c

--- a/go.sum
+++ b/go.sum
@@ -16,9 +16,14 @@ github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/conduitio/conduit-connector-protocol v0.2.0 h1:gwYXVKEMgTtU67ephQ5WwTGIDbT/eTLA9Mdr9Bnbqxc=
 github.com/conduitio/conduit-connector-protocol v0.2.0/go.mod h1:udCU2AkLcYQoLjAO06tHVL2iFJPw+DamK+wllnj50hk=
+github.com/conduitio/conduit-connector-protocol v0.2.1-0.20220802135043-4b89a6c94401 h1:YXw/DQ8j1RjyqLxoWE5MV1s6V6soWolxnzUpIDg4bEY=
+github.com/conduitio/conduit-connector-protocol v0.2.1-0.20220802135043-4b89a6c94401/go.mod h1:jynMd6Kuc7xUABrvYTUrOBuTYAtoQsZ7T6tAB9xAWOo=
 github.com/conduitio/conduit-connector-sdk v0.2.0 h1:yReJT3SOAGqJIlk59WC5FPgpv0Gg+NG4NFj6FJ89XnM=
 github.com/conduitio/conduit-connector-sdk v0.2.0/go.mod h1:zZ/YJqhIZyXdVmFJS55zqkukpBmB+ohbX2kDduoj8Z0=
+github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220803121801-c861a0fb207c h1:hINPPA0bEJ/MkfQcM/HdVLcD+lqD8bpq3mLPeGsi/1s=
+github.com/conduitio/conduit-connector-sdk v0.2.1-0.20220803121801-c861a0fb207c/go.mod h1:+68a3+2KGaPTvTL+4UFcE2H0Gk29fg9LJb3fVcjdoRU=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -118,6 +123,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.26.1 h1:/ihwxqH+4z8UxyI70wM1z9yCvkWcfz/a3mj48k/Zngc=
 github.com/rs/zerolog v1.26.1/go.mod h1:/wSSJWX7lVrsOwlbyTRSOJvqRlc+WjWlfes+CiJ+tmc=
+github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
+github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -129,9 +136,13 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
+go.buf.build/grpc/go/conduitio/conduit-connector-protocol v1.3.3 h1:Nlr9Dm1z7OoG4S1ic1yuwVU8oreR2eFofiJt5v8+zok=
+go.buf.build/grpc/go/conduitio/conduit-connector-protocol v1.3.3/go.mod h1:0IIr2GMOsGd1hPPfwQMmXMXnME6jZSER4C2JS/+BrLc=
 go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol v1.4.1 h1:EHYFlC8XppCJX8C3TS06BC3xA6ctiowDlySWErdOaXU=
 go.buf.build/library/go-grpc/conduitio/conduit-connector-protocol v1.4.1/go.mod h1:iYPhlwHzhRoPYviJbA604qT6wYuQghfrebmXUXLKjk8=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
+go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
+go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -141,6 +152,7 @@ golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -210,6 +222,7 @@ golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200717024301-6ddee64345a6/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.7/go.mod h1:LGqMHiF4EqQNHR1JncWGqT5BVaXmza+X+BDGol+dOxo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
@@ -232,6 +245,7 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=

--- a/source.go
+++ b/source.go
@@ -56,13 +56,12 @@ func (s *Source) Read(ctx context.Context) (sdk.Record, error) {
 		if !ok {
 			return sdk.Record{}, s.tail.Err()
 		}
-		return sdk.Record{
-			Position:  sdk.Position(strconv.FormatInt(line.SeekInfo.Offset, 10)),
-			Operation: sdk.OperationCreate,
-			Payload: sdk.Change{
-				After: sdk.RawData(line.Text),
-			},
-		}, nil
+		return s.Util.NewRecordCreate(
+			sdk.Position(strconv.FormatInt(line.SeekInfo.Offset, 10)),
+			nil,
+			nil,
+			sdk.RawData(line.Text),
+		), nil
 	case <-ctx.Done():
 		return sdk.Record{}, ctx.Err()
 	}

--- a/source.go
+++ b/source.go
@@ -58,7 +58,7 @@ func (s *Source) Read(ctx context.Context) (sdk.Record, error) {
 		if !ok {
 			return sdk.Record{}, s.tail.Err()
 		}
-		return s.Util.NewRecordCreate(
+		return sdk.Util.Source.NewRecordCreate(
 			sdk.Position(strconv.FormatInt(line.SeekInfo.Offset, 10)),
 			map[string]string{
 				MetadataFilePath: s.config[ConfigPath],

--- a/source.go
+++ b/source.go
@@ -25,6 +25,8 @@ import (
 	"github.com/nxadm/tail"
 )
 
+const MetadataFilePath = "file.path"
+
 // Source connector
 type Source struct {
 	sdk.UnimplementedSource
@@ -58,9 +60,11 @@ func (s *Source) Read(ctx context.Context) (sdk.Record, error) {
 		}
 		return s.Util.NewRecordCreate(
 			sdk.Position(strconv.FormatInt(line.SeekInfo.Offset, 10)),
-			nil,
-			nil,
-			sdk.RawData(line.Text),
+			map[string]string{
+				MetadataFilePath: s.config[ConfigPath],
+			},
+			sdk.RawData(strconv.Itoa(line.Num)), // use line number as key
+			sdk.RawData(line.Text),              // use line content as payload
 		), nil
 	case <-ctx.Done():
 		return sdk.Record{}, ctx.Err()

--- a/source.go
+++ b/source.go
@@ -59,8 +59,8 @@ func (s *Source) Read(ctx context.Context) (sdk.Record, error) {
 		return sdk.Record{
 			Position:  sdk.Position(strconv.FormatInt(line.SeekInfo.Offset, 10)),
 			Operation: sdk.OperationCreate,
-			After: sdk.Entity{
-				Payload: sdk.RawData(line.Text),
+			Payload: sdk.Change{
+				After: sdk.RawData(line.Text),
 			},
 		}, nil
 	case <-ctx.Done():

--- a/spec.go
+++ b/spec.go
@@ -21,7 +21,11 @@ import (
 func Specification() sdk.Specification {
 	return sdk.Specification{
 		Name:    "file",
-		Summary: "A file source and destination plugin for Conduit, written in Go.",
+		Summary: "A file source and destination plugin for Conduit.",
+		Description: `The file source allows you to listen to a local file and
+detect any changes happening to it. Each change will create a new record. The
+destination allows you to write record payloads to a destination file, each new
+record payload is appended to the file in a new line.`,
 		Version: "v0.1.0",
 		Author:  "Meroxa, Inc.",
 		DestinationParams: map[string]sdk.Parameter{


### PR DESCRIPTION
### Description

Updates SDK to the latest version and integrates OpenCDC record into the connector. The functionality changed a bit, the connector now writes the whole record JSON into the file instead of only the payload. In the future the SDK will be able to control what gets written into the file because the connector uses `sdk.Record.Bytes()`. This PR also adds acceptance tests.

Depends on https://github.com/ConduitIO/conduit-connector-sdk/pull/31 (needs to be merged and we need to update the connector SDK version).

Related to https://github.com/ConduitIO/conduit/issues/512.

### Quick checks:

- [X] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [X] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-file/pulls) for the same update/change.
- [X] I have written unit tests. (acceptance tests)
- [X] I have made sure that the PR is of reasonable size and can be easily reviewed.
