### PR TITLE
Fix source params

### DIFF
--- a/source.go
+++ b/source.go
@@ -52,7 +52,7 @@ func (s *Source) Parameters() config.Parameters {
 }
 
 func (s *Source) Configure(ctx context.Context, cfg config.Config) error {
-	err := sdk.Util.ParseConfig(ctx, cfg, &s.config, s.config.Parameters())
+	err := sdk.Util.ParseConfig(ctx, cfg, &s.config, NewSource().Parameters())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Description

Parameters should be provided through `NewSource()`, because it includes the middleware configuration parameters.

### Quick checks:

- [ ] I have followed the [Code Guidelines](https://github.com/ConduitIO/conduit/blob/main/docs/code_guidelines.md).
- [ ] There is no other [pull request](https://github.com/ConduitIO/conduit-connector-file/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.
