### PR TITLE
ci: add registry publish workflow (registry Gate 4 pilot)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,92 @@
+# Publish workflow for conduit-connector-file.
+#
+# Adapted from ConduitIO/connector-publish-action's reference-publish-workflow.yml.
+# Triggered by a version tag push: this workflow's OWN identity
+# (ConduitIO/conduit-connector-file/.github/workflows/publish.yml@<tag>) is what
+# becomes the pinned publisher.expectedIdentityPattern on first registration in
+# the connector registry. See the action's README ("Why composite, not
+# reusable").
+#
+# Three jobs: build (cosign-keyless sign, this repo's identity) -> provenance
+# (SLSA L3 via the slsa-github-generator reusable workflow, isolated) -> register
+# (open/update the index-repo PR).
+
+name: publish
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write   # upload release assets
+  id-token: write   # cosign keyless OIDC + SLSA provenance OIDC
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      artifacts: ${{ steps.publish.outputs.artifacts }}
+      resolved-identity: ${{ steps.publish.outputs.resolved-identity }}
+      hashes: ${{ steps.hash.outputs.hashes }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build + cosign-sign the artifact matrix
+        id: publish
+        uses: ConduitIO/connector-publish-action@v1
+        with:
+          mode: build
+          connector-name: file
+          version: ${{ github.ref_name }}
+          build-command: |
+            CGO_ENABLED=0 go build -o "$OUTPUT_PATH" ./cmd/connector
+
+      - name: Format subjects for the SLSA generator
+        id: hash
+        env:
+          # Passed via env (not interpolated into the shell) so the artifacts
+          # JSON can never break the quoting / inject a command.
+          ARTIFACTS: ${{ steps.publish.outputs.artifacts }}
+        run: |
+          echo "hashes=$(printf '%s' "$ARTIFACTS" | \
+            jq -r '[.[] | "\(.sha256)  \(.url | split("/") | last)"] | join("\n")' | base64 -w0)" >> "$GITHUB_OUTPUT"
+
+  provenance:
+    needs: build
+    permissions:
+      actions: read     # generator reads the build job's workflow run
+      id-token: write   # its own OIDC identity — THIS becomes builder.id
+      contents: write   # uploads the provenance attestation as a release asset
+    # Pinned to the ref that IS conduit's pkg/registry/trust.ExpectedBuilderID.
+    # connector-publish-action's test/canary/generator_ref_test.go fails at PR
+    # time if this ref ever drifts from that constant.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
+    with:
+      base64-subjects: ${{ needs.build.outputs.hashes }}
+      upload-assets: true
+
+  register:
+    needs: [build, provenance]
+    permissions:
+      contents: read
+      id-token: write   # this job's own cosign identity must resolve the same as build's
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Open/update the index-repo PR
+        uses: ConduitIO/connector-publish-action@v1
+        with:
+          mode: publish
+          connector-name: file
+          version: ${{ github.ref_name }}
+          min-conduit-version: '0.15.0'
+          min-protocol-version: '0.9.0'
+          repository: https://github.com/ConduitIO/conduit-connector-file
+          # First-registration only — a human-authored, tag-scoped identity
+          # fragment. Omit on subsequent version bumps (routing.Decide ignores
+          # it once the name exists).
+          first-registration-identity-ref-pattern: 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+'
+          provenance-bundle-url: ${{ needs.provenance.outputs.provenance-bundle-url }}
+          index-repo-token: ${{ secrets.REGISTRY_INDEX_PR_TOKEN }}


### PR DESCRIPTION
## What

Adds `publish.yml` so a version-tag push builds, cosign-keyless-signs, SLSA-L3-provenances, and registers this connector in the ConduitIO connector registry. Copied from `ConduitIO/connector-publish-action`'s reference workflow, adapted for `file` (`connector-name: file`, `build ./cmd/connector`).

This is the **first real end-to-end run of the publish Action against a connector repo** — the cross-repo validation deferred in the action's PR-1 review (the canary only ever ran same-repo).

## How it works (three jobs)

1. `build` — the composite Action builds the artifact matrix and cosign-keyless-signs (this repo's workflow identity becomes the pinned `publisher.expectedIdentityPattern`).
2. `provenance` — `slsa-github-generator@v2.1.0` (the ref that IS conduit's `trust.ExpectedBuilderID`) generates isolated SLSA L3 provenance.
3. `register` — the Action opens a new-name PR on `conduit-connector-registry`.

## Prerequisite before it can run

The repo needs a `REGISTRY_INDEX_PR_TOKEN` secret — a fine-grained PAT with **Contents: write + Pull requests: write on `ConduitIO/conduit-connector-registry`** — so the register job can open the index PR.

## Security note

The subjects-format step passes the Action's `artifacts` JSON via `env:` rather than interpolating it into the shell (injection-safe). The upstream reference workflow should get the same one-line fix.

## After merge

Cut a fresh patch tag `v0.10.4` → the workflow runs → produces a signed release + provenance + opens the index PR (which then gets human-reviewed against the registration checklist and merged). No automerge on the index repo until index-CI re-verification exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)