### PR TITLE
fix(ci): publish.yml + goreleaser coexistence on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # The Action uploads signed assets with `gh release upload` (no create),
+      # so the release must exist first. release.yml (GoReleaser) also creates
+      # it on this same tag — both fire in parallel with no ordering. Create it
+      # here if absent (idempotent: `|| true` on the already-exists race);
+      # GoReleaser's `release.mode: keep-existing` then tolerates it. --generate-notes
+      # gives reasonable notes even when this step wins the race.
+      - name: Ensure the release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          gh release create "$TAG" --repo "$GITHUB_REPOSITORY" --verify-tag \
+            --title "$TAG" --generate-notes \
+            || echo "release $TAG already exists — nothing to create"
+
       - name: Build + cosign-sign the artifact matrix
         id: publish
         uses: ConduitIO/connector-publish-action@v1

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,10 @@
 version: 2
+# keep-existing: tolerate a release the registry publish.yml may have already
+# created (both workflows fire on a version tag). GoReleaser adds its user
+# binaries without failing on, or deleting, the publish Action's signed
+# artifacts. See .github/workflows/publish.yml's "Ensure the release exists".
+release:
+  mode: keep-existing
 builds:
   - main: ./cmd/connector/main.go
     goos:


### PR DESCRIPTION
## What

Makes the registry `publish.yml` and the existing `release.yml` (GoReleaser) coexist safely when both fire on a version tag — found by the Gate-4 registry pilot before it could break all 6 seed connectors.

## The bug

The publish Action uploads signed assets with `gh release upload` (which does **not** create a release). GoReleaser creates the release on the same tag. The two workflows run in **parallel with no ordering**, so the Action's upload can run before the release exists → flaky failure. GoReleaser also had no explicit `release.mode`, so its behavior against a pre-existing release was uncertain.

## The fix (Option B)

- `publish.yml`: an **Ensure the release exists** step (`gh release create --verify-tag --generate-notes || true`) before the build, so the release is present regardless of which workflow wins.
- `.goreleaser.yml`: `release.mode: keep-existing` — GoReleaser tolerates the existing release and doesn't delete the Action's signed artifacts. The Action's `--clobber` handles any asset-name overlap.

Race-safe in both directions; neither workflow deletes the other's assets.

## Follow-up

The same ensure-release step should be folded into `connector-publish-action`'s `reference-publish-workflow.yml` so every connector (and external authors) gets it. Tracking that separately.

## Risk tier: Tier-3 (CI). Doesn't run until a version tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)