### PR TITLE
chore: bump to v0.10.4 (registry seed release)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ pipelines:
     connectors:
       - id: example
         plugin: "file"
-        type: source
         settings:
           # Path is the file path used by the connector to read/write records.
           # Type: string
@@ -97,7 +96,6 @@ pipelines:
     connectors:
       - id: example
         plugin: "file"
-        type: destination
         settings:
           # Path is the file path used by the connector to read/write records.
           # Type: string

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ pipelines:
     connectors:
       - id: example
         plugin: "file"
+        type: source
         settings:
           # Path is the file path used by the connector to read/write records.
           # Type: string
@@ -96,6 +97,7 @@ pipelines:
     connectors:
       - id: example
         plugin: "file"
+        type: destination
         settings:
           # Path is the file path used by the connector to read/write records.
           # Type: string

--- a/connector.yaml
+++ b/connector.yaml
@@ -19,7 +19,7 @@ specification:
 
     The Destination connector will create the file if it doesn't exist, and
     records with changes will be appended to the destination file when received.
-  version: v0.10.3
+  version: v0.10.4
   author: Meroxa, Inc.
   source:
     parameters:


### PR DESCRIPTION
Bumps connector.yaml to v0.10.4 so the release tag validates against check_connector_tag. First signed release for the connector registry (Gate-4 pilot). Tier-3 chore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)