### PR TITLE
fix(ci): pass artifacts-json to publish register job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,9 @@ jobs:
           mode: publish
           connector-name: file
           version: ${{ github.ref_name }}
+          # build artifacts from job 1 — required because build and publish are
+          # separate jobs (a step output can't cross a job boundary).
+          artifacts-json: ${{ needs.build.outputs.artifacts }}
           min-conduit-version: '0.15.0'
           min-protocol-version: '0.9.0'
           repository: https://github.com/ConduitIO/conduit-connector-file


### PR DESCRIPTION
Wires needs.build.outputs.artifacts into the publish Action's register job (new artifacts-json input). Required for the registry publish flow to reach index-PR registration. Pairs with connector-publish-action #3. Tier-3 CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)