### PR TITLE
chore: bump to v0.10.5 (registry seed pilot)

### DIFF
--- a/connector.yaml
+++ b/connector.yaml
@@ -19,7 +19,7 @@ specification:
 
     The Destination connector will create the file if it doesn't exist, and
     records with changes will be appended to the destination file when received.
-  version: v0.10.4
+  version: v0.10.5
   author: Meroxa, Inc.
   source:
     parameters:


### PR DESCRIPTION
Fresh version for the registry seed registration now that registry.conduitdata.io/index.json serves a verifiable index. Tier-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)