### PR TITLE
chore: bump to v0.10.6

### DIFF
--- a/connector.yaml
+++ b/connector.yaml
@@ -19,7 +19,7 @@ specification:
 
     The Destination connector will create the file if it doesn't exist, and
     records with changes will be appended to the destination file when received.
-  version: v0.10.5
+  version: v0.10.6
   author: Meroxa, Inc.
   source:
     parameters:


### PR DESCRIPTION
Re-release with the corrected sigstore bundle format so conduit can verify the signature. Tier-3.