### PR TITLE
fix(ci): provenance-bundle-url + bump v0.10.7

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -106,5 +106,5 @@ jobs:
           # fragment. Omit on subsequent version bumps (routing.Decide ignores
           # it once the name exists).
           first-registration-identity-ref-pattern: 'refs/tags/v[0-9]+\.[0-9]+\.[0-9]+'
-          provenance-bundle-url: ${{ needs.provenance.outputs.provenance-bundle-url }}
+          provenance-bundle-url: https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ needs.provenance.outputs.provenance-name }}
           index-repo-token: ${{ secrets.REGISTRY_INDEX_PR_TOKEN }}

--- a/connector.yaml
+++ b/connector.yaml
@@ -19,7 +19,7 @@ specification:
 
     The Destination connector will create the file if it doesn't exist, and
     records with changes will be appended to the destination file when received.
-  version: v0.10.6
+  version: v0.10.7
   author: Meroxa, Inc.
   source:
     parameters:


### PR DESCRIPTION
The slsa generator has no `provenance-bundle-url` output (it's `provenance-name`); the empty value meant no `slsaProvenance` in the index → install failed `registry.provenance_invalid`. Construct the real URL. Found by Gate-6 install. Tier-3.